### PR TITLE
Set movement counter keymap to be silent ( Fix for Issue #4)

### DIFF
--- a/lua/bad_practices/hjkl.lua
+++ b/lua/bad_practices/hjkl.lua
@@ -40,7 +40,7 @@ function M.setup(opts)
             'n',
             key,
             ':lua require("bad_practices/hjkl").reset_all()<CR>:echo<CR>'..key,
-            {unique = true, noremap = true}
+            {unique = true, noremap = true, silent = true}
         )
     end
 
@@ -49,7 +49,7 @@ function M.setup(opts)
             'n',
             key,
             ':lua require("bad_practices/hjkl").reset_all()<CR>:echo<CR>'..key,
-            {unique = true, noremap = true}
+            {unique = true, noremap = true, silent = true}
         )
     end
 end


### PR DESCRIPTION
This is a suggested fix for #4 

The keymap which resets the counter for the 'hjkl' keys has been set to silent.

