### PR TITLE
feat: Add snacks support

### DIFF
--- a/lua/bad_practices/util.lua
+++ b/lua/bad_practices/util.lua
@@ -6,12 +6,10 @@ local function check_has_notify_plugin()
     return pcall(function() require('notify') end)
 end
 local function check_has_snacks_plugin()
-	if pcall(function()
-		require("snacks")
-	end) then
-		return Snacks.config.notifier.enabled
-	end
-	return false
+    if pcall(function() require("snacks") end) then
+        return Snacks.config.notifier.enabled
+    end
+    return false
 end
 
 local last_shown_dict = {}
@@ -38,19 +36,19 @@ local notify = {
     default = function(msg)
         -- use echo instead of echom or echoerr to avoid saving message to :messages
         vim.cmd("echohl WarningMsg | echo '" .. msg .. "' | echohl None")
-	end,
-	pretty_notify = function(msg)
-		require("notify")(msg, "ERROR", {
-			title = "BadPractices",
-			icon = "●",
-		})
-	end,
-	pretty_snacks = function(msg)
-		Snacks.notifier.notify(msg, "error", {
-			title = "BadPractices",
-			style = "compact",
-		})
-	end,
+    end,
+    pretty_notify = function(msg)
+        require("notify")(msg, "ERROR", {
+            title = "BadPractices",
+            icon = "●",
+        })
+    end,
+    pretty_snacks = function(msg)
+        Snacks.notifier.notify(msg, "error", {
+            title = "BadPractices",
+            style = "compact",
+        })
+    end
 }
 
 -- uses nvim-notify if installed
@@ -62,13 +60,13 @@ function M.print_warn(msg)
         last_shown_dict[msg] = now
 
     end
-		if check_has_notify_plugin() then
-			notify.pretty_notify(msg)
-		elseif check_has_snacks_plugin() then
-			notify.pretty_snacks(msg)
-		else
-			notify.default(msg)
-		end
+    if check_has_notify_plugin() then
+    	notify.pretty_notify(msg)
+    elseif check_has_snacks_plugin() then
+    	notify.pretty_snacks(msg)
+    else
+    	notify.default(msg)
+    end
 end
 
 return M

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A plugin to help give up bad practices in neovim.
 
 ![bad-practices 1](https://user-images.githubusercontent.com/18750590/122595373-fc79ca80-d085-11eb-82fa-df1e3774dedd.gif)
 
-Alternatively if you have [nvim-notify](https://github.com/rcarriga/nvim-notify) installed you can get pretty notifications about tapping into bad practices.
+Alternatively if you have [nvim-notify](https://github.com/rcarriga/nvim-notify) or [snacks.nvim](https://github.com/folke/snacks.nvim) installed you can get pretty notifications about tapping into bad practices.
 
 ## Installation
 


### PR DESCRIPTION
This adds support for [snacks.nvim](https://github.com/folke/snacks.nvim) in the same way as for vim-notify.

For example, if you use AstroNvim it uses snacks to do the pretty notifications